### PR TITLE
Update Yandex Music connector

### DIFF
--- a/src/connectors/yandex-music.ts
+++ b/src/connectors/yandex-music.ts
@@ -17,7 +17,7 @@ function isOldPlayer() {
 	);
 }
 
-function setupOldConnector() {
+function setupNewConnector() {
 	// Player
 	Connector.playerSelector = 'section[class*=PlayerBar_root__]';
 
@@ -63,7 +63,7 @@ function setupOldConnector() {
 	};
 }
 
-function setupNewConnector() {
+function setupOldConnector() {
 	let trackInfo = {};
 	let isPlaying = false;
 

--- a/src/connectors/yandex-music.ts
+++ b/src/connectors/yandex-music.ts
@@ -17,11 +17,9 @@ function isOldPlayer() {
 	);
 }
 
-function setupNewConnector() {
-	Connector.playerSelector = [
-		'section[class*=PlayerBarDesktop_root__]',
-		'section[class*=PlayerBarMobile_root__]',
-	];
+function setupOldConnector() {
+	// Player
+	Connector.playerSelector = 'section[class*=PlayerBar_root__]';
 
 	Connector.pauseButtonSelector = [
 		'button[aria-label=Pause]',
@@ -30,17 +28,42 @@ function setupNewConnector() {
 		'button[aria-label=Үзіліс]',
 	];
 
-	Connector.trackSelector = 'section span[class*=Meta_title__]';
+	// Track info
+	Connector.trackSelector = `${Connector.playerSelector} span[class*=Meta_title__]`;
 
-	Connector.artistSelector = 'section span[class*=Meta_artistCaption__]';
+	Connector.artistSelector = `${Connector.playerSelector} span[class*=Meta_artistCaption__]`;
 
 	Connector.trackArtSelector = [
 		'section img[class*=PlayerBarDesktop_cover__]',
 		'section img[class*=PlayerBarMobile_cover__]',
 	];
+
+	// Duration
+	Connector.currentTimeSelector =
+		'section span[class*=Timecode_root_start__]';
+	Connector.durationSelector = 'section span[class*=Timecode_root_end__]';
+
+	// Likes
+	Connector.loveButtonSelector = [
+		'div[class*=PlayerBarDesktop_infoButtons__] button',
+		'div[class*=PlayerBarMobile_infoButtons__] button',
+	];
+
+	Connector.isLoved = () => {
+		const loved = Util.getAttrFromSelectors(
+			Connector.loveButtonSelector,
+			'aria-pressed',
+		);
+
+		if (loved === null) {
+			return null;
+		}
+
+		return loved === 'true';
+	};
 }
 
-function setupOldConnector() {
+function setupNewConnector() {
 	let trackInfo = {};
 	let isPlaying = false;
 


### PR DESCRIPTION
(Possibly), after the latest updates to Yandex Music, the wrong track name and artist started to be used when scrobbling. Also, there was no indication of track time for the connector and there was no possibility to like a track.
This PR fixes the issues described above.